### PR TITLE
Bump gRPC version to use 1.18.0

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -25,7 +25,7 @@ eos
   gem.add_runtime_dependency 'google-api-client', '0.23.9'
   gem.add_runtime_dependency 'google-cloud-logging', '1.5.4'
   gem.add_runtime_dependency 'google-protobuf', '3.6.1'
-  gem.add_runtime_dependency 'grpc', '1.18.0'
+  gem.add_runtime_dependency 'grpc', '~> 1.18.0'
   gem.add_runtime_dependency 'json', '2.1.0'
 
   gem.add_development_dependency 'mocha', '~> 1.1'

--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -25,7 +25,7 @@ eos
   gem.add_runtime_dependency 'google-api-client', '0.23.9'
   gem.add_runtime_dependency 'google-cloud-logging', '1.5.4'
   gem.add_runtime_dependency 'google-protobuf', '3.6.1'
-  gem.add_runtime_dependency 'grpc', '1.8.3'
+  gem.add_runtime_dependency 'grpc', '1.18.0'
   gem.add_runtime_dependency 'json', '2.1.0'
 
   gem.add_development_dependency 'mocha', '~> 1.1'


### PR DESCRIPTION
If the gcloud gem is installed, we saw issues with td-agent:

```
'check_version_conflict': can't activate grpc-1.8.3-x86_64-linux, already activated grpc-1.18.0-x86_64-linux
```